### PR TITLE
Create Geo-based.md

### DIFF
--- a/OpenAI/Geo-based.md
+++ b/OpenAI/Geo-based.md
@@ -1,0 +1,37 @@
+# The probability of finding multiple Latinos with the same name in the New Jersey region depends on several factors, including:
+
+1. **Population Size**: New Jersey has a significant Latino population. As of recent estimates, Latinos make up about 20-22% of the state’s population (~9 million total residents).
+
+2. **Common Latino Names**: Certain names like **José, Juan, Carlos, Maria, and Luis** are quite common within Latino communities, increasing the likelihood of repetition.
+
+3. **Name Distribution & Clustering**: Urban areas such as **Newark, Paterson, Jersey City, and Elizabeth** have dense Latino populations. This clustering effect increases the probability of name duplication within these areas.
+
+4. **Statistical Probability**:
+   - Given that a significant portion of Latinos share common surnames (e.g., Rodríguez, Martínez, García, Hernández), and combining this with common first names, the probability of finding duplicates rises significantly.
+   - Using a **birthday paradox**-like approach: if there are **N** individuals in a given Latino community with a set of the most common names, the probability of at least two having the same full name follows a probabilistic collision model.
+
+5. **Real-World Estimates**:
+   - In a city like **Paterson (~60% Latino)** with ~150,000 people, assuming ~50,000 share the most common Latino names, the probability of multiple **"José Rodríguez"** or **"Maria González"** appearing is extremely high (well above 90%).
+   - In a smaller suburban town, it decreases but remains nontrivial.
+
+### Conclusion:
+The probability of encountering multiple Latinos with the same name in New Jersey is **very high**, particularly in densely populated Latino communities. If you're referring to exact name matches (full name, including first and last name), a rough estimate suggests a **50-80% chance** in larger Latino hubs and a **20-40% chance** in less dense areas.
+
+The probability of finding multiple Latinos with the same name in the New Jersey region depends on several factors, including:
+
+1. **Population Size**: New Jersey has a significant Latino population. As of recent estimates, Latinos make up about 20-22% of the state’s population (~9 million total residents).
+
+2. **Common Latino Names**: Certain names like **José, Juan, Carlos, Maria, and Luis** are quite common within Latino communities, increasing the likelihood of repetition.
+
+3. **Name Distribution & Clustering**: Urban areas such as **Newark, Paterson, Jersey City, and Elizabeth** have dense Latino populations. This clustering effect increases the probability of name duplication within these areas.
+
+4. **Statistical Probability**:
+   - Given that a significant portion of Latinos share common surnames (e.g., Rodríguez, Martínez, García, Hernández), and combining this with common first names, the probability of finding duplicates rises significantly.
+   - Using a **birthday paradox**-like approach: if there are **N** individuals in a given Latino community with a set of the most common names, the probability of at least two having the same full name follows a probabilistic collision model.
+
+5. **Real-World Estimates**:
+   - In a city like **Paterson (~60% Latino)** with ~150,000 people, assuming ~50,000 share the most common Latino names, the probability of multiple **"José Rodríguez"** or **"Maria González"** appearing is extremely high (well above 90%).
+   - In a smaller suburban town, it decreases but remains nontrivial.
+
+### Conclusion:
+The probability of encountering multiple Latinos with the same name in New Jersey is **very high**, particularly in densely populated Latino communities. If you're referring to exact name matches (full name, including first and last name), a rough estimate suggests a **50-80% chance** in larger Latino hubs and a **20-40% chance** in less dense areas.


### PR DESCRIPTION
# The probability of finding multiple Latinos with the same name in the New Jersey region depends on several factors, including:

1. **Population Size**: New Jersey has a significant Latino population. As of recent estimates, Latinos make up about 20-22% of the state’s population (~9 million total residents).

2. **Common Latino Names**: Certain names like **José, Juan, Carlos, Maria, and Luis** are quite common within Latino communities, increasing the likelihood of repetition.

3. **Name Distribution & Clustering**: Urban areas such as **Newark, Paterson, Jersey City, and Elizabeth** have dense Latino populations. This clustering effect increases the probability of name duplication within these areas.

4. **Statistical Probability**:
   - Given that a significant portion of Latinos share common surnames (e.g., Rodríguez, Martínez, García, Hernández), and combining this with common first names, the probability of finding duplicates rises significantly.
   - Using a **birthday paradox**-like approach: if there are **N** individuals in a given Latino community with a set of the most common names, the probability of at least two having the same full name follows a probabilistic collision model.

5. **Real-World Estimates**:
   - In a city like **Paterson (~60% Latino)** with ~150,000 people, assuming ~50,000 share the most common Latino names, the probability of multiple **"José Rodríguez"** or **"Maria González"** appearing is extremely high (well above 90%).
   - In a smaller suburban town, it decreases but remains nontrivial.

### Conclusion:
The probability of encountering multiple Latinos with the same name in New Jersey is **very high**, particularly in densely populated Latino communities. If you're referring to exact name matches (full name, including first and last name), a rough estimate suggests a **50-80% chance** in larger Latino hubs and a **20-40% chance** in less dense areas.

The probability of finding multiple Latinos with the same name in the New Jersey region depends on several factors, including:

1. **Population Size**: New Jersey has a significant Latino population. As of recent estimates, Latinos make up about 20-22% of the state’s population (~9 million total residents).

2. **Common Latino Names**: Certain names like **José, Juan, Carlos, Maria, and Luis** are quite common within Latino communities, increasing the likelihood of repetition.

3. **Name Distribution & Clustering**: Urban areas such as **Newark, Paterson, Jersey City, and Elizabeth** have dense Latino populations. This clustering effect increases the probability of name duplication within these areas.

4. **Statistical Probability**:
   - Given that a significant portion of Latinos share common surnames (e.g., Rodríguez, Martínez, García, Hernández), and combining this with common first names, the probability of finding duplicates rises significantly.
   - Using a **birthday paradox**-like approach: if there are **N** individuals in a given Latino community with a set of the most common names, the probability of at least two having the same full name follows a probabilistic collision model.

5. **Real-World Estimates**:
   - In a city like **Paterson (~60% Latino)** with ~150,000 people, assuming ~50,000 share the most common Latino names, the probability of multiple **"José Rodríguez"** or **"Maria González"** appearing is extremely high (well above 90%).
   - In a smaller suburban town, it decreases but remains nontrivial.

### Conclusion:
The probability of encountering multiple Latinos with the same name in New Jersey is **very high**, particularly in densely populated Latino communities. If you're referring to exact name matches (full name, including first and last name), a rough estimate suggests a **50-80% chance** in larger Latino hubs and a **20-40% chance** in less dense areas.